### PR TITLE
Split CI checks into separate GitHub Actions jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
+  lint-and-typecheck:
+    name: Lint and Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -34,8 +35,59 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+  conventional-commits:
+    name: Conventional Commits
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate commit messages
+        run: bunx commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+
+  production-build:
+    name: Production Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Build
         run: bun run build
+
+  unit-tests-and-coverage:
+    name: Unit Tests and Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Test (coverage)
         run: bun run test:coverage


### PR DESCRIPTION
## Summary
- split the single CI job into separate lint/typecheck, commitlint, build, and test jobs
- keep the same workflow triggers and validations while exposing each job as its own PR status check
- rename the workflow to `CI/CD` so the GitHub checks UI reads cleanly

## Testing
- bunx prettier --check .github/workflows/ci.yml