### PR TITLE
fix: align editor table headers with cells

### DIFF
--- a/src/components/editor/EditorTable.tsx
+++ b/src/components/editor/EditorTable.tsx
@@ -1294,15 +1294,22 @@ const EntryRow = memo(function EntryRow({
           verticalAlign: 'middle',
           padding: '8px 8px',
           overflow: 'hidden',
-          textAlign: 'center',
         }}
       >
-        <Checkbox
-          checked={isChecked}
-          onChange={(e) => onToggleSelection(e.currentTarget.checked)}
-          onClick={(e) => e.stopPropagation()}
-          aria-label={`Select entry ${entry.msgid}`}
-        />
+        <Box
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Checkbox
+            checked={isChecked}
+            onChange={(e) => onToggleSelection(e.currentTarget.checked)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select entry ${entry.msgid}`}
+          />
+        </Box>
       </Table.Td>
       {visibleDataColumns.map((columnKey) => {
         if (columnKey === 'status') {


### PR DESCRIPTION
## Summary
- align desktop table header padding with table cell padding in the editor table
- fix the slight right shift between column labels and their cell content

## Verification
- `bun run lint` failed locally: `eslint` not found
- `bun run format:check` failed locally: `prettier` not found
- `bun run typecheck` failed locally: `tsc` not found
- `bun run build` failed locally: `tsc` not found
- `bun run test:coverage` failed locally: `vitest` not found
- `node_modules` is missing in this worktree, so the full CI script surface could not run locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical spacing in table headers for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->