### PR TITLE
fix: disable single-string translate actions without DeepL keys

### DIFF
--- a/src/components/editor/TranslateButton.test.tsx
+++ b/src/components/editor/TranslateButton.test.tsx
@@ -26,7 +26,7 @@ describe('TranslateButton', () => {
 
     renderWithMantine('icon');
 
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', { name: /translate with deepl/i });
     expect(button).toBeDisabled();
 
     await user.click(button);
@@ -41,7 +41,7 @@ describe('TranslateButton', () => {
 
     renderWithMantine('icon');
 
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', { name: /translate with deepl/i });
     await user.hover(button.parentElement as HTMLElement);
 
     expect(

--- a/src/components/editor/TranslateButton.tsx
+++ b/src/components/editor/TranslateButton.tsx
@@ -156,7 +156,7 @@ export function TranslateButton({
     }
 
     return (
-      <ActionIcon size={size} variant="subtle" disabled>
+      <ActionIcon size={size} variant="subtle" disabled aria-label="Translating">
         <Loader size={iconSize} />
       </ActionIcon>
     );
@@ -188,6 +188,7 @@ export function TranslateButton({
           color="red"
           onClick={doTranslate}
           disabled={isDisabled}
+          aria-label="Retry translation"
         >
           <AlertCircle size={iconSize} />
         </ActionIcon>
@@ -219,6 +220,7 @@ export function TranslateButton({
                 color={glossaryId ? 'teal' : 'blue'}
                 onClick={doTranslate}
                 disabled={isDisabled}
+                aria-label={label}
               >
                 <Languages size={iconSize} />
               </ActionIcon>


### PR DESCRIPTION
## Summary
- disable single-string DeepL translate actions when no user API key is configured
- apply the guard in the shared TranslateButton component so inline and inspector/sidebar actions stay in sync
- add focused tests for both icon and button render paths

## Validation
- bun run lint
- bun run format:check
- bun run typecheck
- bun run build
- bun run test src/components/editor/TranslateButton.test.tsx

## Notes
- `bun run test:coverage` still fails due a pre-existing Vitest storage issue where multiple existing suites error with `localStorage.clear is not a function` before assertions run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for the translate button's behavior when API authentication is not configured.

* **Bug Fixes**
  * Fixed translate button to properly disable when API credentials are missing, preventing errors when users attempt translation without proper setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->