### PR TITLE
fix: confirm before replacing loaded file via URL

### DIFF
--- a/src/lib/app-language/locales/app.en.po
+++ b/src/lib/app-language/locales/app.en.po
@@ -21,7 +21,7 @@ msgstr "API key is valid!"
 msgid "Action"
 msgstr "Action"
 
-#: src/pages/Index.tsx:1429
+#: src/pages/Index.tsx:1445
 msgid "Actions"
 msgstr "Actions"
 
@@ -33,7 +33,7 @@ msgstr "Adjust the appearance of the editor to suit your screen and preferences.
 msgid "Allow follow-up questions about this feedback"
 msgstr "Allow follow-up questions about this feedback"
 
-#: src/pages/Index.tsx:1583
+#: src/pages/Index.tsx:1614
 msgid "Auto-saved {age}"
 msgstr "Auto-saved {age}"
 
@@ -62,15 +62,15 @@ msgstr "Choose which language GlossBoss uses for its interface."
 msgid "Clear"
 msgstr "Clear"
 
-#: src/pages/Index.tsx:1451
+#: src/pages/Index.tsx:1467
 msgid "Clear anyway"
 msgstr "Clear anyway"
 
-#: src/pages/Index.tsx:1435
+#: src/pages/Index.tsx:1451
 msgid "Clear editor"
 msgstr "Clear editor"
 
-#: src/pages/Index.tsx:1448
+#: src/pages/Index.tsx:1464
 msgid "Clear editor?"
 msgstr "Clear editor?"
 
@@ -102,7 +102,7 @@ msgstr ""
 "Controls the tone of DeepL translations. Not all languages support formality"
 "."
 
-#: src/pages/Index.tsx:765
+#: src/pages/Index.tsx:756
 msgid ""
 "Could not fetch the file. The server may not allow cross-origin requests. Tr"
 "y downloading the file and uploading it directly."
@@ -136,7 +136,7 @@ msgstr "DeepL ready"
 msgid "DeepL ready ({count} terms)"
 msgstr "DeepL ready ({count} terms)"
 
-#: src/pages/Index.tsx:1605
+#: src/pages/Index.tsx:1636
 msgid "DeepL synced"
 msgstr "DeepL synced"
 
@@ -160,7 +160,7 @@ msgstr "Development"
 msgid "Development Mode Only"
 msgstr "Development Mode Only"
 
-#: src/pages/Index.tsx:1566
+#: src/pages/Index.tsx:1597
 msgid "Discard and use fresh file"
 msgstr "Discard and use fresh file"
 
@@ -172,19 +172,19 @@ msgstr "Discard changes and exit the current field"
 msgid "Display"
 msgstr "Display"
 
-#: src/pages/Index.tsx:1320
+#: src/pages/Index.tsx:1336
 msgid "Download"
 msgstr "Download"
 
-#: src/pages/Index.tsx:1359
+#: src/pages/Index.tsx:1375
 msgid "Download as"
 msgstr "Download as"
 
-#: src/pages/Index.tsx:1303
+#: src/pages/Index.tsx:1319
 msgid "Download as {format}"
 msgstr "Download as {format}"
 
-#: src/pages/Index.tsx:1666
+#: src/pages/Index.tsx:1697
 msgid ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
@@ -192,11 +192,11 @@ msgstr ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
 
-#: src/pages/Index.tsx:1103
+#: src/pages/Index.tsx:1119
 msgid "Drop it like it's hot"
 msgstr "Drop it like it's hot"
 
-#: src/pages/Index.tsx:1270
+#: src/pages/Index.tsx:1286
 msgid "Edit gettext translation files with DeepL integration"
 msgstr "Edit gettext translation files with DeepL integration"
 
@@ -228,7 +228,7 @@ msgstr "Failed to initialize verification."
 msgid "Failed to load glossary"
 msgstr "Failed to load glossary"
 
-#: src/pages/Index.tsx:1476
+#: src/pages/Index.tsx:1507
 msgid "Failed to parse file"
 msgstr "Failed to parse file"
 
@@ -240,7 +240,7 @@ msgstr "Failed to read the file."
 msgid "Feature"
 msgstr "Feature"
 
-#: src/pages/Index.tsx:1403
+#: src/pages/Index.tsx:1419
 msgid "Feedback"
 msgstr "Feedback"
 
@@ -248,11 +248,11 @@ msgstr "Feedback"
 msgid "Feedback could not be submitted at this time."
 msgstr "Feedback could not be submitted at this time."
 
-#: src/pages/Index.tsx:1231
+#: src/pages/Index.tsx:1247
 msgid "Feedback failed"
 msgstr "Feedback failed"
 
-#: src/pages/Index.tsx:1188
+#: src/pages/Index.tsx:1204
 msgid "Feedback submitted"
 msgstr "Feedback submitted"
 
@@ -264,7 +264,7 @@ msgstr "Feedback verification is not configured."
 msgid "File does not appear to be a valid WordPress glossary CSV."
 msgstr "File does not appear to be a valid WordPress glossary CSV."
 
-#: src/pages/Index.tsx:1125
+#: src/pages/Index.tsx:1141
 msgid "File downloaded"
 msgstr "File downloaded"
 
@@ -288,7 +288,7 @@ msgstr "Free: 500,000 chars/month • Pro: Pay per use"
 msgid "Glossary"
 msgstr "Glossary"
 
-#: src/pages/Index.tsx:1598
+#: src/pages/Index.tsx:1629
 msgid "Glossary: {count} terms ({locale})"
 msgstr "Glossary: {count} terms ({locale})"
 
@@ -321,7 +321,7 @@ msgstr "Keyboard shortcuts available when editing translations."
 msgid "Language"
 msgstr "Language"
 
-#: src/pages/Index.tsx:1764
+#: src/pages/Index.tsx:1795
 msgid "License"
 msgstr "License"
 
@@ -329,7 +329,7 @@ msgstr "License"
 msgid "Light mode"
 msgstr "Light mode"
 
-#: src/pages/Index.tsx:1483
+#: src/pages/Index.tsx:1514
 msgid "Line {line}"
 msgstr "Line {line}"
 
@@ -337,7 +337,7 @@ msgstr "Line {line}"
 msgid "List steps someone else can follow"
 msgstr "List steps someone else can follow"
 
-#: src/pages/Index.tsx:1707
+#: src/pages/Index.tsx:1738
 msgid "Load"
 msgstr "Load"
 
@@ -345,11 +345,11 @@ msgstr "Load"
 msgid "Load Glossary"
 msgstr "Load Glossary"
 
-#: src/pages/Index.tsx:1715
+#: src/pages/Index.tsx:1746
 msgid "Load a small example WordPress plugin PO file (Hello Dolly)"
 msgstr "Load a small example WordPress plugin PO file (Hello Dolly)"
 
-#: src/pages/Index.tsx:1726
+#: src/pages/Index.tsx:1757
 msgid "Load example PO"
 msgstr "Load example PO"
 
@@ -360,6 +360,14 @@ msgid ""
 msgstr ""
 "Load the official WordPress translation glossary to ensure consistent termin"
 "ology."
+
+#: src/pages/Index.tsx:1480
+msgid ""
+"Loading a new file from URL will replace the currently loaded file. Any unsa"
+"ved changes will be lost."
+msgstr ""
+"Loading a new file from URL will replace the currently loaded file. Any unsa"
+"ved changes will be lost."
 
 #: src/components/SettingsModal.tsx:186
 msgid "Navigation Settings"
@@ -386,23 +394,23 @@ msgstr "No glossary entries found in the uploaded file."
 msgid "Only visible while running the app in development mode"
 msgstr "Only visible while running the app in development mode"
 
-#: src/pages/Index.tsx:1213
+#: src/pages/Index.tsx:1229
 msgid "Open issue"
 msgstr "Open issue"
 
-#: src/pages/Index.tsx:1426
+#: src/pages/Index.tsx:1442
 msgid "Open settings"
 msgstr "Open settings"
 
-#: src/pages/Index.tsx:1361
+#: src/pages/Index.tsx:1377
 msgid "PO file (.po)"
 msgstr "PO file (.po)"
 
-#: src/pages/Index.tsx:1690
+#: src/pages/Index.tsx:1721
 msgid "PO file URL"
 msgstr "PO file URL"
 
-#: src/pages/Index.tsx:1689
+#: src/pages/Index.tsx:1720
 msgid "Paste a .po file URL"
 msgstr "Paste a .po file URL"
 
@@ -435,7 +443,7 @@ msgid "Previous field"
 msgstr "Previous field"
 
 #: src/components/feedback/FeedbackModal.tsx:416
-#: src/pages/Index.tsx:1784
+#: src/pages/Index.tsx:1815
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -459,7 +467,7 @@ msgstr "Read the translation guide"
 msgid "Refresh from WordPress.org"
 msgstr "Refresh from WordPress.org"
 
-#: src/pages/Index.tsx:1105
+#: src/pages/Index.tsx:1121
 msgid "Release to load your translation file"
 msgstr "Release to load your translation file"
 
@@ -471,11 +479,19 @@ msgstr "Remember API key across sessions"
 msgid "Remove saved key"
 msgstr "Remove saved key"
 
-#: src/pages/Index.tsx:763
+#: src/pages/Index.tsx:1483
+msgid "Replace"
+msgstr "Replace"
+
+#: src/pages/Index.tsx:1479
+msgid "Replace current file?"
+msgstr "Replace current file?"
+
+#: src/pages/Index.tsx:754
 msgid "Request timed out. Try downloading the file and uploading it directly."
 msgstr "Request timed out. Try downloading the file and uploading it directly."
 
-#: src/pages/Index.tsx:1557
+#: src/pages/Index.tsx:1588
 msgid "Restore draft"
 msgstr "Restore draft"
 
@@ -517,11 +533,11 @@ msgid "Send feedback"
 msgstr "Send feedback"
 
 #: src/components/SettingsModal.tsx:464
-#: src/pages/Index.tsx:1421
+#: src/pages/Index.tsx:1437
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Index.tsx:1412
+#: src/pages/Index.tsx:1428
 msgid "Settings and actions"
 msgstr "Settings and actions"
 
@@ -533,7 +549,7 @@ msgstr "Settings saved!"
 msgid "Share Feedback"
 msgstr "Share Feedback"
 
-#: src/pages/Index.tsx:1396
+#: src/pages/Index.tsx:1412
 msgid "Share feedback"
 msgstr "Share feedback"
 
@@ -565,7 +581,7 @@ msgstr ""
 msgid "Skip translated entries"
 msgstr "Skip translated entries"
 
-#: src/pages/Index.tsx:1754
+#: src/pages/Index.tsx:1785
 msgid "Source"
 msgstr "Source"
 
@@ -597,11 +613,11 @@ msgstr "Terms in selected text:"
 msgid "Test Connection"
 msgstr "Test Connection"
 
-#: src/pages/Index.tsx:1200
+#: src/pages/Index.tsx:1216
 msgid "Thanks. Issue #{issueNumber} was created."
 msgstr "Thanks. Issue #{issueNumber} was created."
 
-#: src/pages/Index.tsx:696
+#: src/pages/Index.tsx:779
 msgid "The URL must start with https://"
 msgstr "The URL must start with https://"
 
@@ -613,7 +629,7 @@ msgstr ""
 "These tools only appear while running the app locally in development and are"
 " not shown in production."
 
-#: src/pages/Index.tsx:1450
+#: src/pages/Index.tsx:1466
 msgid "This will remove all your work on the current file."
 msgstr "This will remove all your work on the current file."
 
@@ -622,7 +638,7 @@ msgstr "This will remove all your work on the current file."
 msgid "Title"
 msgstr "Title"
 
-#: src/pages/Index.tsx:1774
+#: src/pages/Index.tsx:1805
 msgid "Translate"
 msgstr "Translate"
 
@@ -635,19 +651,19 @@ msgid "Turnstile site key not set. Using local development bypass."
 msgstr "Turnstile site key not set. Using local development bypass."
 
 #: src/components/SettingsModal.tsx:387
-#: src/pages/Index.tsx:770
+#: src/pages/Index.tsx:761
 msgid "Unknown error"
 msgstr "Unknown error"
 
-#: src/pages/Index.tsx:1531
+#: src/pages/Index.tsx:1562
 msgid "Unsaved draft found"
 msgstr "Unsaved draft found"
 
-#: src/pages/Index.tsx:1385
+#: src/pages/Index.tsx:1401
 msgid "Update"
 msgstr "Update"
 
-#: src/pages/Index.tsx:1373
+#: src/pages/Index.tsx:1389
 msgid ""
 "Update this file using a .pot template. Existing translations are kept when "
 "source strings still match, new strings are added, and obsolete strings are "
@@ -657,11 +673,11 @@ msgstr ""
 "source strings still match, new strings are added, and obsolete strings are "
 "removed."
 
-#: src/pages/Index.tsx:1155
+#: src/pages/Index.tsx:1171
 msgid "Updated"
 msgstr "Updated"
 
-#: src/pages/Index.tsx:1283
+#: src/pages/Index.tsx:1299
 msgid "Upload"
 msgstr "Upload"
 
@@ -673,11 +689,11 @@ msgstr "Upload CSV"
 msgid "Upload a WordPress glossary CSV for the selected language"
 msgstr "Upload a WordPress glossary CSV for the selected language"
 
-#: src/pages/Index.tsx:1664
+#: src/pages/Index.tsx:1695
 msgid "Upload a translation file to start"
 msgstr "Upload a translation file to start"
 
-#: src/pages/Index.tsx:1462
+#: src/pages/Index.tsx:1493
 msgid "Upload failed"
 msgstr "Upload failed"
 
@@ -741,15 +757,15 @@ msgstr ""
 msgid "When would you use this?"
 msgstr "When would you use this?"
 
-#: src/pages/Index.tsx:1578
+#: src/pages/Index.tsx:1609
 msgid "Working from draft"
 msgstr "Working from draft"
 
-#: src/pages/Index.tsx:1302
+#: src/pages/Index.tsx:1318
 msgid "You have unsaved changes"
 msgstr "You have unsaved changes"
 
-#: src/pages/Index.tsx:1539
+#: src/pages/Index.tsx:1570
 msgid ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
@@ -757,7 +773,7 @@ msgstr ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
 
-#: src/pages/Index.tsx:1449
+#: src/pages/Index.tsx:1465
 msgid "You have unsaved changes. Are you sure you want to clear the editor?"
 msgstr "You have unsaved changes. Are you sure you want to clear the editor?"
 
@@ -769,11 +785,11 @@ msgstr "characters"
 msgid "for details."
 msgstr "for details."
 
-#: src/pages/Index.tsx:1364
+#: src/pages/Index.tsx:1380
 msgid "i18next JSON (.json)"
 msgstr "i18next JSON (.json)"
 
-#: src/pages/Index.tsx:1712
+#: src/pages/Index.tsx:1743
 msgid "or"
 msgstr "or"
 
@@ -785,6 +801,6 @@ msgstr "or upload manually"
 msgid "terms"
 msgstr "terms"
 
-#: src/pages/Index.tsx:1547
+#: src/pages/Index.tsx:1578
 msgid "{count} modified entries will be restored."
 msgstr "{count} modified entries will be restored."

--- a/src/lib/app-language/locales/app.nl.po
+++ b/src/lib/app-language/locales/app.nl.po
@@ -21,7 +21,7 @@ msgstr "De API-sleutel is geldig!"
 msgid "Action"
 msgstr "Actie"
 
-#: src/pages/Index.tsx:1429
+#: src/pages/Index.tsx:1445
 msgid "Actions"
 msgstr "Acties"
 
@@ -33,7 +33,7 @@ msgstr "Pas het uiterlijk van de editor aan op je scherm en voorkeuren."
 msgid "Allow follow-up questions about this feedback"
 msgstr "Vervolgvragen over deze feedback toestaan"
 
-#: src/pages/Index.tsx:1583
+#: src/pages/Index.tsx:1614
 msgid "Auto-saved {age}"
 msgstr "Automatisch opgeslagen {age}"
 
@@ -62,15 +62,15 @@ msgstr "Kies welke taal GlossBoss voor de interface gebruikt."
 msgid "Clear"
 msgstr "Wissen"
 
-#: src/pages/Index.tsx:1451
+#: src/pages/Index.tsx:1467
 msgid "Clear anyway"
 msgstr "Toch wissen"
 
-#: src/pages/Index.tsx:1435
+#: src/pages/Index.tsx:1451
 msgid "Clear editor"
 msgstr "Editor wissen"
 
-#: src/pages/Index.tsx:1448
+#: src/pages/Index.tsx:1464
 msgid "Clear editor?"
 msgstr "Editor wissen?"
 
@@ -102,7 +102,7 @@ msgstr ""
 "Bepaalt de toon van DeepL-vertalingen. Niet alle talen ondersteunen formalit"
 "eit."
 
-#: src/pages/Index.tsx:765
+#: src/pages/Index.tsx:756
 msgid ""
 "Could not fetch the file. The server may not allow cross-origin requests. Tr"
 "y downloading the file and uploading it directly."
@@ -135,7 +135,7 @@ msgstr "DeepL klaar"
 msgid "DeepL ready ({count} terms)"
 msgstr "DeepL klaar ({count} termen)"
 
-#: src/pages/Index.tsx:1605
+#: src/pages/Index.tsx:1636
 msgid "DeepL synced"
 msgstr "DeepL gesynchroniseerd"
 
@@ -159,7 +159,7 @@ msgstr "Ontwikkeling"
 msgid "Development Mode Only"
 msgstr "Alleen in ontwikkelmodus"
 
-#: src/pages/Index.tsx:1566
+#: src/pages/Index.tsx:1597
 msgid "Discard and use fresh file"
 msgstr "Verwerpen en een nieuw bestand gebruiken"
 
@@ -171,19 +171,19 @@ msgstr "Wijzigingen verwerpen en het huidige veld verlaten"
 msgid "Display"
 msgstr "Weergave"
 
-#: src/pages/Index.tsx:1320
+#: src/pages/Index.tsx:1336
 msgid "Download"
 msgstr "Downloaden"
 
-#: src/pages/Index.tsx:1359
+#: src/pages/Index.tsx:1375
 msgid "Download as"
 msgstr "Downloaden als"
 
-#: src/pages/Index.tsx:1303
+#: src/pages/Index.tsx:1319
 msgid "Download as {format}"
 msgstr "Downloaden als {format}"
 
-#: src/pages/Index.tsx:1666
+#: src/pages/Index.tsx:1697
 msgid ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
@@ -191,11 +191,11 @@ msgstr ""
 "Sleep je vertaalbestand hierheen of klik om te bladeren. Je vertalingen word"
 "en lokaal in je browser opgeslagen."
 
-#: src/pages/Index.tsx:1103
+#: src/pages/Index.tsx:1119
 msgid "Drop it like it's hot"
 msgstr "Laat maar vallen"
 
-#: src/pages/Index.tsx:1270
+#: src/pages/Index.tsx:1286
 msgid "Edit gettext translation files with DeepL integration"
 msgstr "Bewerk gettext-vertaalbestanden met DeepL-integratie"
 
@@ -229,7 +229,7 @@ msgstr "Initialiseren van verificatie mislukt."
 msgid "Failed to load glossary"
 msgstr "Woordenlijst laden mislukt"
 
-#: src/pages/Index.tsx:1476
+#: src/pages/Index.tsx:1507
 msgid "Failed to parse file"
 msgstr "Bestand kon niet worden verwerkt"
 
@@ -241,7 +241,7 @@ msgstr "Het bestand kon niet worden gelezen."
 msgid "Feature"
 msgstr "Functie"
 
-#: src/pages/Index.tsx:1403
+#: src/pages/Index.tsx:1419
 msgid "Feedback"
 msgstr "Feedback"
 
@@ -249,11 +249,11 @@ msgstr "Feedback"
 msgid "Feedback could not be submitted at this time."
 msgstr "Feedback kan op dit moment niet worden verzonden."
 
-#: src/pages/Index.tsx:1231
+#: src/pages/Index.tsx:1247
 msgid "Feedback failed"
 msgstr "Feedback mislukt"
 
-#: src/pages/Index.tsx:1188
+#: src/pages/Index.tsx:1204
 msgid "Feedback submitted"
 msgstr "Feedback verzonden"
 
@@ -265,7 +265,7 @@ msgstr "Feedbackverificatie is niet geconfigureerd."
 msgid "File does not appear to be a valid WordPress glossary CSV."
 msgstr "Het bestand lijkt geen geldige WordPress-woordenlijst-CSV te zijn."
 
-#: src/pages/Index.tsx:1125
+#: src/pages/Index.tsx:1141
 msgid "File downloaded"
 msgstr "Bestand gedownload"
 
@@ -289,7 +289,7 @@ msgstr "Gratis: 500.000 tekens/maand • Pro: betalen naar gebruik"
 msgid "Glossary"
 msgstr "Woordenlijst"
 
-#: src/pages/Index.tsx:1598
+#: src/pages/Index.tsx:1629
 msgid "Glossary: {count} terms ({locale})"
 msgstr "Woordenlijst: {count} termen ({locale})"
 
@@ -322,7 +322,7 @@ msgstr "Sneltoetsen die beschikbaar zijn tijdens het bewerken van vertalingen."
 msgid "Language"
 msgstr "Taal"
 
-#: src/pages/Index.tsx:1764
+#: src/pages/Index.tsx:1795
 msgid "License"
 msgstr "Licentie"
 
@@ -330,7 +330,7 @@ msgstr "Licentie"
 msgid "Light mode"
 msgstr "Lichte modus"
 
-#: src/pages/Index.tsx:1483
+#: src/pages/Index.tsx:1514
 msgid "Line {line}"
 msgstr "Regel {line}"
 
@@ -338,7 +338,7 @@ msgstr "Regel {line}"
 msgid "List steps someone else can follow"
 msgstr "Som stappen op die iemand anders kan volgen"
 
-#: src/pages/Index.tsx:1707
+#: src/pages/Index.tsx:1738
 msgid "Load"
 msgstr ""
 
@@ -346,11 +346,11 @@ msgstr ""
 msgid "Load Glossary"
 msgstr "Woordenlijst laden"
 
-#: src/pages/Index.tsx:1715
+#: src/pages/Index.tsx:1746
 msgid "Load a small example WordPress plugin PO file (Hello Dolly)"
 msgstr "Laad een klein voorbeeld-PO-bestand van een WordPress-plugin (Hello Dolly)"
 
-#: src/pages/Index.tsx:1726
+#: src/pages/Index.tsx:1757
 msgid "Load example PO"
 msgstr "Voorbeeld-PO laden"
 
@@ -361,6 +361,12 @@ msgid ""
 msgstr ""
 "Laad de officiële WordPress-vertaalwoordenlijst voor consistente terminologi"
 "e."
+
+#: src/pages/Index.tsx:1480
+msgid ""
+"Loading a new file from URL will replace the currently loaded file. Any unsa"
+"ved changes will be lost."
+msgstr ""
 
 #: src/components/SettingsModal.tsx:186
 msgid "Navigation Settings"
@@ -387,23 +393,23 @@ msgstr "Geen woordenlijstingangen gevonden in het geüploade bestand."
 msgid "Only visible while running the app in development mode"
 msgstr "Alleen zichtbaar wanneer de app in ontwikkelmodus draait"
 
-#: src/pages/Index.tsx:1213
+#: src/pages/Index.tsx:1229
 msgid "Open issue"
 msgstr "Issue openen"
 
-#: src/pages/Index.tsx:1426
+#: src/pages/Index.tsx:1442
 msgid "Open settings"
 msgstr "Instellingen openen"
 
-#: src/pages/Index.tsx:1361
+#: src/pages/Index.tsx:1377
 msgid "PO file (.po)"
 msgstr "PO-bestand (.po)"
 
-#: src/pages/Index.tsx:1690
+#: src/pages/Index.tsx:1721
 msgid "PO file URL"
 msgstr ""
 
-#: src/pages/Index.tsx:1689
+#: src/pages/Index.tsx:1720
 msgid "Paste a .po file URL"
 msgstr ""
 
@@ -436,7 +442,7 @@ msgid "Previous field"
 msgstr "Vorig veld"
 
 #: src/components/feedback/FeedbackModal.tsx:416
-#: src/pages/Index.tsx:1784
+#: src/pages/Index.tsx:1815
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -460,7 +466,7 @@ msgstr "Lees de vertaalgids"
 msgid "Refresh from WordPress.org"
 msgstr "Verversen vanaf WordPress.org"
 
-#: src/pages/Index.tsx:1105
+#: src/pages/Index.tsx:1121
 msgid "Release to load your translation file"
 msgstr "Laat los om je vertaalbestand te laden"
 
@@ -472,11 +478,19 @@ msgstr "API-sleutel onthouden tussen sessies"
 msgid "Remove saved key"
 msgstr "Opgeslagen sleutel verwijderen"
 
-#: src/pages/Index.tsx:763
+#: src/pages/Index.tsx:1483
+msgid "Replace"
+msgstr ""
+
+#: src/pages/Index.tsx:1479
+msgid "Replace current file?"
+msgstr ""
+
+#: src/pages/Index.tsx:754
 msgid "Request timed out. Try downloading the file and uploading it directly."
 msgstr ""
 
-#: src/pages/Index.tsx:1557
+#: src/pages/Index.tsx:1588
 msgid "Restore draft"
 msgstr "Concept herstellen"
 
@@ -520,11 +534,11 @@ msgid "Send feedback"
 msgstr "Feedback versturen"
 
 #: src/components/SettingsModal.tsx:464
-#: src/pages/Index.tsx:1421
+#: src/pages/Index.tsx:1437
 msgid "Settings"
 msgstr "Instellingen"
 
-#: src/pages/Index.tsx:1412
+#: src/pages/Index.tsx:1428
 msgid "Settings and actions"
 msgstr "Instellingen en acties"
 
@@ -536,7 +550,7 @@ msgstr "Instellingen opgeslagen!"
 msgid "Share Feedback"
 msgstr "Feedback delen"
 
-#: src/pages/Index.tsx:1396
+#: src/pages/Index.tsx:1412
 msgid "Share feedback"
 msgstr "Feedback delen"
 
@@ -568,7 +582,7 @@ msgstr ""
 msgid "Skip translated entries"
 msgstr "Vertaalde items overslaan"
 
-#: src/pages/Index.tsx:1754
+#: src/pages/Index.tsx:1785
 msgid "Source"
 msgstr "Bron"
 
@@ -600,11 +614,11 @@ msgstr "Termen in geselecteerde tekst:"
 msgid "Test Connection"
 msgstr "Verbinding testen"
 
-#: src/pages/Index.tsx:1200
+#: src/pages/Index.tsx:1216
 msgid "Thanks. Issue #{issueNumber} was created."
 msgstr "Bedankt. Issue #{issueNumber} is aangemaakt."
 
-#: src/pages/Index.tsx:696
+#: src/pages/Index.tsx:779
 msgid "The URL must start with https://"
 msgstr ""
 
@@ -616,7 +630,7 @@ msgstr ""
 "Deze hulpmiddelen verschijnen alleen wanneer de app lokaal in ontwikkelmodus"
 " draait en worden niet in productie getoond."
 
-#: src/pages/Index.tsx:1450
+#: src/pages/Index.tsx:1466
 msgid "This will remove all your work on the current file."
 msgstr "Dit verwijdert al je werk aan het huidige bestand."
 
@@ -625,7 +639,7 @@ msgstr "Dit verwijdert al je werk aan het huidige bestand."
 msgid "Title"
 msgstr "Titel"
 
-#: src/pages/Index.tsx:1774
+#: src/pages/Index.tsx:1805
 msgid "Translate"
 msgstr "Vertalen"
 
@@ -638,19 +652,19 @@ msgid "Turnstile site key not set. Using local development bypass."
 msgstr "Turnstile-sitekey is niet ingesteld. Lokale ontwikkel-bypass wordt gebruikt."
 
 #: src/components/SettingsModal.tsx:387
-#: src/pages/Index.tsx:770
+#: src/pages/Index.tsx:761
 msgid "Unknown error"
 msgstr "Onbekende fout"
 
-#: src/pages/Index.tsx:1531
+#: src/pages/Index.tsx:1562
 msgid "Unsaved draft found"
 msgstr "Niet-opgeslagen concept gevonden"
 
-#: src/pages/Index.tsx:1385
+#: src/pages/Index.tsx:1401
 msgid "Update"
 msgstr "Bijwerken"
 
-#: src/pages/Index.tsx:1373
+#: src/pages/Index.tsx:1389
 msgid ""
 "Update this file using a .pot template. Existing translations are kept when "
 "source strings still match, new strings are added, and obsolete strings are "
@@ -660,11 +674,11 @@ msgstr ""
 "houden zolang bronteksten nog overeenkomen, nieuwe teksten worden toegevoegd"
 " en verouderde teksten verwijderd."
 
-#: src/pages/Index.tsx:1155
+#: src/pages/Index.tsx:1171
 msgid "Updated"
 msgstr "Bijgewerkt"
 
-#: src/pages/Index.tsx:1283
+#: src/pages/Index.tsx:1299
 msgid "Upload"
 msgstr "Uploaden"
 
@@ -676,11 +690,11 @@ msgstr "CSV uploaden"
 msgid "Upload a WordPress glossary CSV for the selected language"
 msgstr "Upload een WordPress-woordenlijst-CSV voor de geselecteerde taal"
 
-#: src/pages/Index.tsx:1664
+#: src/pages/Index.tsx:1695
 msgid "Upload a translation file to start"
 msgstr "Upload een vertaalbestand om te beginnen"
 
-#: src/pages/Index.tsx:1462
+#: src/pages/Index.tsx:1493
 msgid "Upload failed"
 msgstr "Upload mislukt"
 
@@ -745,15 +759,15 @@ msgstr ""
 msgid "When would you use this?"
 msgstr "Wanneer zou je dit gebruiken?"
 
-#: src/pages/Index.tsx:1578
+#: src/pages/Index.tsx:1609
 msgid "Working from draft"
 msgstr "Werkt vanuit concept"
 
-#: src/pages/Index.tsx:1302
+#: src/pages/Index.tsx:1318
 msgid "You have unsaved changes"
 msgstr "Je hebt niet-opgeslagen wijzigingen"
 
-#: src/pages/Index.tsx:1539
+#: src/pages/Index.tsx:1570
 msgid ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
@@ -761,7 +775,7 @@ msgstr ""
 "Je hebt niet-opgeslagen wijzigingen van {age}. Wil je je vorige werk herstel"
 "len?"
 
-#: src/pages/Index.tsx:1449
+#: src/pages/Index.tsx:1465
 msgid "You have unsaved changes. Are you sure you want to clear the editor?"
 msgstr ""
 "Je hebt niet-opgeslagen wijzigingen. Weet je zeker dat je de editor wilt wis"
@@ -775,11 +789,11 @@ msgstr "tekens"
 msgid "for details."
 msgstr "voor details."
 
-#: src/pages/Index.tsx:1364
+#: src/pages/Index.tsx:1380
 msgid "i18next JSON (.json)"
 msgstr "i18next JSON (.json)"
 
-#: src/pages/Index.tsx:1712
+#: src/pages/Index.tsx:1743
 msgid "or"
 msgstr ""
 
@@ -791,6 +805,6 @@ msgstr "of handmatig uploaden"
 msgid "terms"
 msgstr "termen"
 
-#: src/pages/Index.tsx:1547
+#: src/pages/Index.tsx:1578
 msgid "{count} modified entries will be restored."
 msgstr "{count} gewijzigde items worden hersteld."

--- a/src/lib/app-language/locales/app.pot
+++ b/src/lib/app-language/locales/app.pot
@@ -21,7 +21,7 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: src/pages/Index.tsx:1429
+#: src/pages/Index.tsx:1445
 msgid "Actions"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Allow follow-up questions about this feedback"
 msgstr ""
 
-#: src/pages/Index.tsx:1583
+#: src/pages/Index.tsx:1614
 msgid "Auto-saved {age}"
 msgstr ""
 
@@ -62,15 +62,15 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: src/pages/Index.tsx:1451
+#: src/pages/Index.tsx:1467
 msgid "Clear anyway"
 msgstr ""
 
-#: src/pages/Index.tsx:1435
+#: src/pages/Index.tsx:1451
 msgid "Clear editor"
 msgstr ""
 
-#: src/pages/Index.tsx:1448
+#: src/pages/Index.tsx:1464
 msgid "Clear editor?"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgid ""
 "."
 msgstr ""
 
-#: src/pages/Index.tsx:765
+#: src/pages/Index.tsx:756
 msgid ""
 "Could not fetch the file. The server may not allow cross-origin requests. Tr"
 "y downloading the file and uploading it directly."
@@ -127,7 +127,7 @@ msgstr ""
 msgid "DeepL ready ({count} terms)"
 msgstr ""
 
-#: src/pages/Index.tsx:1605
+#: src/pages/Index.tsx:1636
 msgid "DeepL synced"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Development Mode Only"
 msgstr ""
 
-#: src/pages/Index.tsx:1566
+#: src/pages/Index.tsx:1597
 msgid "Discard and use fresh file"
 msgstr ""
 
@@ -163,29 +163,29 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: src/pages/Index.tsx:1320
+#: src/pages/Index.tsx:1336
 msgid "Download"
 msgstr ""
 
-#: src/pages/Index.tsx:1359
+#: src/pages/Index.tsx:1375
 msgid "Download as"
 msgstr ""
 
-#: src/pages/Index.tsx:1303
+#: src/pages/Index.tsx:1319
 msgid "Download as {format}"
 msgstr ""
 
-#: src/pages/Index.tsx:1666
+#: src/pages/Index.tsx:1697
 msgid ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
 msgstr ""
 
-#: src/pages/Index.tsx:1103
+#: src/pages/Index.tsx:1119
 msgid "Drop it like it's hot"
 msgstr ""
 
-#: src/pages/Index.tsx:1270
+#: src/pages/Index.tsx:1286
 msgid "Edit gettext translation files with DeepL integration"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgstr ""
 msgid "Failed to load glossary"
 msgstr ""
 
-#: src/pages/Index.tsx:1476
+#: src/pages/Index.tsx:1507
 msgid "Failed to parse file"
 msgstr ""
 
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: src/pages/Index.tsx:1403
+#: src/pages/Index.tsx:1419
 msgid "Feedback"
 msgstr ""
 
@@ -237,11 +237,11 @@ msgstr ""
 msgid "Feedback could not be submitted at this time."
 msgstr ""
 
-#: src/pages/Index.tsx:1231
+#: src/pages/Index.tsx:1247
 msgid "Feedback failed"
 msgstr ""
 
-#: src/pages/Index.tsx:1188
+#: src/pages/Index.tsx:1204
 msgid "Feedback submitted"
 msgstr ""
 
@@ -253,7 +253,7 @@ msgstr ""
 msgid "File does not appear to be a valid WordPress glossary CSV."
 msgstr ""
 
-#: src/pages/Index.tsx:1125
+#: src/pages/Index.tsx:1141
 msgid "File downloaded"
 msgstr ""
 
@@ -277,7 +277,7 @@ msgstr ""
 msgid "Glossary"
 msgstr ""
 
-#: src/pages/Index.tsx:1598
+#: src/pages/Index.tsx:1629
 msgid "Glossary: {count} terms ({locale})"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: src/pages/Index.tsx:1764
+#: src/pages/Index.tsx:1795
 msgid "License"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Light mode"
 msgstr ""
 
-#: src/pages/Index.tsx:1483
+#: src/pages/Index.tsx:1514
 msgid "Line {line}"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "List steps someone else can follow"
 msgstr ""
 
-#: src/pages/Index.tsx:1707
+#: src/pages/Index.tsx:1738
 msgid "Load"
 msgstr ""
 
@@ -334,11 +334,11 @@ msgstr ""
 msgid "Load Glossary"
 msgstr ""
 
-#: src/pages/Index.tsx:1715
+#: src/pages/Index.tsx:1746
 msgid "Load a small example WordPress plugin PO file (Hello Dolly)"
 msgstr ""
 
-#: src/pages/Index.tsx:1726
+#: src/pages/Index.tsx:1757
 msgid "Load example PO"
 msgstr ""
 
@@ -346,6 +346,12 @@ msgstr ""
 msgid ""
 "Load the official WordPress translation glossary to ensure consistent termin"
 "ology."
+msgstr ""
+
+#: src/pages/Index.tsx:1480
+msgid ""
+"Loading a new file from URL will replace the currently loaded file. Any unsa"
+"ved changes will be lost."
 msgstr ""
 
 #: src/components/SettingsModal.tsx:186
@@ -373,23 +379,23 @@ msgstr ""
 msgid "Only visible while running the app in development mode"
 msgstr ""
 
-#: src/pages/Index.tsx:1213
+#: src/pages/Index.tsx:1229
 msgid "Open issue"
 msgstr ""
 
-#: src/pages/Index.tsx:1426
+#: src/pages/Index.tsx:1442
 msgid "Open settings"
 msgstr ""
 
-#: src/pages/Index.tsx:1361
+#: src/pages/Index.tsx:1377
 msgid "PO file (.po)"
 msgstr ""
 
-#: src/pages/Index.tsx:1690
+#: src/pages/Index.tsx:1721
 msgid "PO file URL"
 msgstr ""
 
-#: src/pages/Index.tsx:1689
+#: src/pages/Index.tsx:1720
 msgid "Paste a .po file URL"
 msgstr ""
 
@@ -422,7 +428,7 @@ msgid "Previous field"
 msgstr ""
 
 #: src/components/feedback/FeedbackModal.tsx:416
-#: src/pages/Index.tsx:1784
+#: src/pages/Index.tsx:1815
 msgid "Privacy"
 msgstr ""
 
@@ -446,7 +452,7 @@ msgstr ""
 msgid "Refresh from WordPress.org"
 msgstr ""
 
-#: src/pages/Index.tsx:1105
+#: src/pages/Index.tsx:1121
 msgid "Release to load your translation file"
 msgstr ""
 
@@ -458,11 +464,19 @@ msgstr ""
 msgid "Remove saved key"
 msgstr ""
 
-#: src/pages/Index.tsx:763
+#: src/pages/Index.tsx:1483
+msgid "Replace"
+msgstr ""
+
+#: src/pages/Index.tsx:1479
+msgid "Replace current file?"
+msgstr ""
+
+#: src/pages/Index.tsx:754
 msgid "Request timed out. Try downloading the file and uploading it directly."
 msgstr ""
 
-#: src/pages/Index.tsx:1557
+#: src/pages/Index.tsx:1588
 msgid "Restore draft"
 msgstr ""
 
@@ -504,11 +518,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: src/components/SettingsModal.tsx:464
-#: src/pages/Index.tsx:1421
+#: src/pages/Index.tsx:1437
 msgid "Settings"
 msgstr ""
 
-#: src/pages/Index.tsx:1412
+#: src/pages/Index.tsx:1428
 msgid "Settings and actions"
 msgstr ""
 
@@ -520,7 +534,7 @@ msgstr ""
 msgid "Share Feedback"
 msgstr ""
 
-#: src/pages/Index.tsx:1396
+#: src/pages/Index.tsx:1412
 msgid "Share feedback"
 msgstr ""
 
@@ -550,7 +564,7 @@ msgstr ""
 msgid "Skip translated entries"
 msgstr ""
 
-#: src/pages/Index.tsx:1754
+#: src/pages/Index.tsx:1785
 msgid "Source"
 msgstr ""
 
@@ -580,11 +594,11 @@ msgstr ""
 msgid "Test Connection"
 msgstr ""
 
-#: src/pages/Index.tsx:1200
+#: src/pages/Index.tsx:1216
 msgid "Thanks. Issue #{issueNumber} was created."
 msgstr ""
 
-#: src/pages/Index.tsx:696
+#: src/pages/Index.tsx:779
 msgid "The URL must start with https://"
 msgstr ""
 
@@ -594,7 +608,7 @@ msgid ""
 " not shown in production."
 msgstr ""
 
-#: src/pages/Index.tsx:1450
+#: src/pages/Index.tsx:1466
 msgid "This will remove all your work on the current file."
 msgstr ""
 
@@ -603,7 +617,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: src/pages/Index.tsx:1774
+#: src/pages/Index.tsx:1805
 msgid "Translate"
 msgstr ""
 
@@ -616,30 +630,30 @@ msgid "Turnstile site key not set. Using local development bypass."
 msgstr ""
 
 #: src/components/SettingsModal.tsx:387
-#: src/pages/Index.tsx:770
+#: src/pages/Index.tsx:761
 msgid "Unknown error"
 msgstr ""
 
-#: src/pages/Index.tsx:1531
+#: src/pages/Index.tsx:1562
 msgid "Unsaved draft found"
 msgstr ""
 
-#: src/pages/Index.tsx:1385
+#: src/pages/Index.tsx:1401
 msgid "Update"
 msgstr ""
 
-#: src/pages/Index.tsx:1373
+#: src/pages/Index.tsx:1389
 msgid ""
 "Update this file using a .pot template. Existing translations are kept when "
 "source strings still match, new strings are added, and obsolete strings are "
 "removed."
 msgstr ""
 
-#: src/pages/Index.tsx:1155
+#: src/pages/Index.tsx:1171
 msgid "Updated"
 msgstr ""
 
-#: src/pages/Index.tsx:1283
+#: src/pages/Index.tsx:1299
 msgid "Upload"
 msgstr ""
 
@@ -651,11 +665,11 @@ msgstr ""
 msgid "Upload a WordPress glossary CSV for the selected language"
 msgstr ""
 
-#: src/pages/Index.tsx:1664
+#: src/pages/Index.tsx:1695
 msgid "Upload a translation file to start"
 msgstr ""
 
-#: src/pages/Index.tsx:1462
+#: src/pages/Index.tsx:1493
 msgid "Upload failed"
 msgstr ""
 
@@ -715,21 +729,21 @@ msgstr ""
 msgid "When would you use this?"
 msgstr ""
 
-#: src/pages/Index.tsx:1578
+#: src/pages/Index.tsx:1609
 msgid "Working from draft"
 msgstr ""
 
-#: src/pages/Index.tsx:1302
+#: src/pages/Index.tsx:1318
 msgid "You have unsaved changes"
 msgstr ""
 
-#: src/pages/Index.tsx:1539
+#: src/pages/Index.tsx:1570
 msgid ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
 msgstr ""
 
-#: src/pages/Index.tsx:1449
+#: src/pages/Index.tsx:1465
 msgid "You have unsaved changes. Are you sure you want to clear the editor?"
 msgstr ""
 
@@ -741,11 +755,11 @@ msgstr ""
 msgid "for details."
 msgstr ""
 
-#: src/pages/Index.tsx:1364
+#: src/pages/Index.tsx:1380
 msgid "i18next JSON (.json)"
 msgstr ""
 
-#: src/pages/Index.tsx:1712
+#: src/pages/Index.tsx:1743
 msgid "or"
 msgstr ""
 
@@ -757,6 +771,6 @@ msgstr ""
 msgid "terms"
 msgstr ""
 
-#: src/pages/Index.tsx:1547
+#: src/pages/Index.tsx:1578
 msgid "{count} modified entries will be restored."
 msgstr ""

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -327,6 +327,7 @@ export default function Index() {
   const [isLoadingExample, setIsLoadingExample] = useState(false);
   const [isLoadingUrl, setIsLoadingUrl] = useState(false);
   const [urlInput, setUrlInput] = useState('');
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const [translateSourceLang, setTranslateSourceLang] = useState<SourceLanguage | undefined>(
     undefined,
@@ -686,19 +687,8 @@ export default function Index() {
     }
   }, [loadFile]);
 
-  const handleLoadFromUrl = useCallback(
+  const executeUrlLoad = useCallback(
     async (url: string) => {
-      if (!url.startsWith('https://')) {
-        setErrors([
-          {
-            severity: 'error',
-            code: 'INVALID_SYNTAX',
-            message: t('The URL must start with https://'),
-          },
-        ]);
-        return;
-      }
-
       setIsLoadingUrl(true);
       setErrors([]);
       setWarnings([]);
@@ -707,6 +697,7 @@ export default function Index() {
       setDragError(null);
       setPendingDraft(null);
       setIsFromDraft(false);
+      setPendingUrl(null);
 
       let timeout: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -778,11 +769,36 @@ export default function Index() {
     [loadFile, t],
   );
 
+  const handleLoadFromUrl = useCallback(
+    (url: string) => {
+      if (!url.startsWith('https://')) {
+        setErrors([
+          {
+            severity: 'error',
+            code: 'INVALID_SYNTAX',
+            message: t('The URL must start with https://'),
+          },
+        ]);
+        return;
+      }
+
+      // If a file is already loaded, ask for confirmation first
+      if (filename) {
+        setPendingUrl(url);
+        return;
+      }
+
+      void executeUrlLoad(url);
+    },
+    [filename, executeUrlLoad, t],
+  );
+
   // Auto-load from ?url= query parameter on mount
   useEffect(() => {
     const urlParam = searchParams.get('url');
-    if (urlParam && !filename) {
+    if (urlParam) {
       setSearchParams({}, { replace: true });
+      // If no file loaded yet, load directly; otherwise handleLoadFromUrl will prompt
       void handleLoadFromUrl(urlParam);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1451,6 +1467,21 @@ export default function Index() {
             confirmLabel={msgid('Clear anyway')}
             confirmColor="red"
             variant="danger"
+          />
+
+          {/* Confirmation modal for URL overwrite */}
+          <ConfirmModal
+            opened={pendingUrl !== null}
+            onClose={() => setPendingUrl(null)}
+            onConfirm={() => {
+              if (pendingUrl) void executeUrlLoad(pendingUrl);
+            }}
+            title={t('Replace current file?')}
+            message={t(
+              'Loading a new file from URL will replace the currently loaded file. Any unsaved changes will be lost.',
+            )}
+            confirmLabel={msgid('Replace')}
+            variant="warning"
           />
 
           {/* Drag error display */}


### PR DESCRIPTION
## Summary

- When a file is already loaded in the editor and the user loads a new file from URL (paste input or `?url=` query parameter), a confirmation modal now appears before replacing the current file
- Prevents accidental loss of unsaved work
- Split `handleLoadFromUrl` into a validation/confirmation gate and `executeUrlLoad` for the actual fetch
- New confirmation modal uses the existing `ConfirmModal` component with `variant="warning"`

## Test plan

- [ ] Load a PO file normally (drag-and-drop or file picker)
- [ ] Paste a URL in the URL input and press Load — confirm modal should appear
- [ ] Cancel the modal — nothing changes, current file stays loaded
- [ ] Confirm the modal — new file loads from URL, replacing the old one
- [ ] Visit `?url=https://...` with a file already loaded — confirm modal should appear
- [ ] Visit `?url=https://...` with no file loaded — loads directly (no modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)