### PR TITLE
chore: add workflow_dispatch to i18n-issues workflow

### DIFF
--- a/.github/workflows/i18n-issues.yml
+++ b/.github/workflows/i18n-issues.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'src/lib/app-language/locales/app.*.po'
+  workflow_dispatch:
 
 jobs:
   manage-translation-issues:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch:` trigger to the i18n-issues workflow so it can be run manually from the Actions tab
- All other workflows already have this trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)