### PR TITLE
chore: sync i18n source references after UI redesign

### DIFF
--- a/src/lib/app-language/locales/app.en.po
+++ b/src/lib/app-language/locales/app.en.po
@@ -9,7 +9,7 @@ msgstr ""
 msgid "+{{count}} more"
 msgstr "+{{count}} more"
 
-#: src/pages/Index.tsx:1624
+#: src/pages/Index.tsx:1626
 msgid "...and {{count}} more warnings"
 msgstr "...and {{count}} more warnings"
 
@@ -150,7 +150,7 @@ msgstr "Auto-detect"
 msgid "Auto-detected: {{slug}}"
 msgstr "Auto-detected: {{slug}}"
 
-#: src/pages/Index.tsx:1691
+#: src/pages/Index.tsx:1693
 msgid "Auto-saved {age}"
 msgstr "Auto-saved {age}"
 
@@ -279,7 +279,7 @@ msgstr "Clear"
 msgid "Clear active source reference"
 msgstr "Clear active source reference"
 
-#: src/pages/Index.tsx:1542
+#: src/pages/Index.tsx:1544
 msgid "Clear anyway"
 msgstr "Clear anyway"
 
@@ -287,7 +287,7 @@ msgstr "Clear anyway"
 msgid "Clear editor"
 msgstr "Clear editor"
 
-#: src/pages/Index.tsx:1539
+#: src/pages/Index.tsx:1541
 msgid "Clear editor?"
 msgstr "Clear editor?"
 
@@ -423,7 +423,7 @@ msgstr "DeepL ready ({count} terms)"
 msgid "DeepL ready ({{count}} terms)"
 msgstr "DeepL ready ({{count}} terms)"
 
-#: src/pages/Index.tsx:1726
+#: src/pages/Index.tsx:1728
 msgid "DeepL synced"
 msgstr "DeepL synced"
 
@@ -471,7 +471,7 @@ msgstr "Development Mode Only"
 msgid "Directory listing is unavailable."
 msgstr "Directory listing is unavailable."
 
-#: src/pages/Index.tsx:1674
+#: src/pages/Index.tsx:1676
 msgid "Discard and use new file"
 msgstr "Discard and use new file"
 
@@ -503,7 +503,7 @@ msgstr "Download as {format}"
 msgid "Download format options"
 msgstr "Download format options"
 
-#: src/pages/Index.tsx:1782
+#: src/pages/Index.tsx:1784
 msgid ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
@@ -541,7 +541,7 @@ msgstr "Edit Header"
 msgid "Edit gettext translation files with DeepL integration"
 msgstr "Edit gettext translation files with DeepL integration"
 
-#: src/pages/Index.tsx:1686
+#: src/pages/Index.tsx:1688
 msgid "Editing draft"
 msgstr "Editing draft"
 
@@ -700,7 +700,7 @@ msgid "Failed to parse POT file"
 msgstr "Failed to parse POT file"
 
 #: src/pages/Index.tsx:664
-#: src/pages/Index.tsx:1582
+#: src/pages/Index.tsx:1584
 msgid "Failed to parse file"
 msgstr "Failed to parse file"
 
@@ -847,7 +847,7 @@ msgstr "German (Germany)"
 msgid "German (Switzerland)"
 msgstr "German (Switzerland)"
 
-#: src/pages/Index.tsx:1490
+#: src/pages/Index.tsx:1491
 msgid "GlossBoss v{version}"
 msgstr "GlossBoss v{version}"
 
@@ -897,7 +897,7 @@ msgstr ""
 "Glossary not found in DeepL. This translation was done without glossary. Re-"
 "sync in Settings is recommended."
 
-#: src/pages/Index.tsx:1719
+#: src/pages/Index.tsx:1721
 msgid "Glossary: {count} terms ({locale})"
 msgstr "Glossary: {count} terms ({locale})"
 
@@ -1092,7 +1092,7 @@ msgstr "Last Updated"
 msgid "Latvian"
 msgstr "Latvian"
 
-#: src/pages/Index.tsx:1507
+#: src/pages/Index.tsx:1509
 msgid "License"
 msgstr "License"
 
@@ -1100,7 +1100,7 @@ msgstr "License"
 msgid "Light mode"
 msgstr "Light mode"
 
-#: src/pages/Index.tsx:1589
+#: src/pages/Index.tsx:1591
 msgid "Line {line}"
 msgstr "Line {line}"
 
@@ -1109,7 +1109,7 @@ msgstr "Line {line}"
 msgid "Line {{lineNumber}}"
 msgstr "Line {{lineNumber}}"
 
-#: src/pages/Index.tsx:1616
+#: src/pages/Index.tsx:1618
 msgid "Line {{line}}"
 msgstr "Line {{line}}"
 
@@ -1124,7 +1124,7 @@ msgid "Lithuanian"
 msgstr "Lithuanian"
 
 #: src/components/editor/GlossaryPanel.tsx:355
-#: src/pages/Index.tsx:1823
+#: src/pages/Index.tsx:1825
 msgid "Load"
 msgstr "Load"
 
@@ -1132,11 +1132,11 @@ msgstr "Load"
 msgid "Load Glossary"
 msgstr "Load Glossary"
 
-#: src/pages/Index.tsx:1831
+#: src/pages/Index.tsx:1833
 msgid "Load a small example WordPress plugin PO file (Hello Dolly)"
 msgstr "Load a small example WordPress plugin PO file (Hello Dolly)"
 
-#: src/pages/Index.tsx:1842
+#: src/pages/Index.tsx:1844
 msgid "Load example PO"
 msgstr "Load example PO"
 
@@ -1153,7 +1153,7 @@ msgstr ""
 msgid "Load voices by testing your key"
 msgstr "Load voices by testing your key"
 
-#: src/pages/Index.tsx:1555
+#: src/pages/Index.tsx:1557
 msgid ""
 "Loading a new file from URL will replace the currently loaded file. Any unsa"
 "ved changes will be lost."
@@ -1404,7 +1404,7 @@ msgstr "Open settings"
 msgid "PO file (.po)"
 msgstr "PO file (.po)"
 
-#: src/pages/Index.tsx:1806
+#: src/pages/Index.tsx:1808
 msgid "PO file URL"
 msgstr "PO file URL"
 
@@ -1412,7 +1412,7 @@ msgstr "PO file URL"
 msgid "POT Created"
 msgstr "POT Created"
 
-#: src/pages/Index.tsx:1805
+#: src/pages/Index.tsx:1807
 msgid "Paste a .po file URL"
 msgstr "Paste a .po file URL"
 
@@ -1527,7 +1527,7 @@ msgid "Previous field"
 msgstr "Previous field"
 
 #: src/components/feedback/FeedbackModal.tsx:416
-#: src/pages/Index.tsx:1525
+#: src/pages/Index.tsx:1527
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -1596,11 +1596,11 @@ msgid "Remove saved key"
 msgstr "Remove saved key"
 
 #: src/components/editor/TranslateButton.tsx:260
-#: src/pages/Index.tsx:1558
+#: src/pages/Index.tsx:1560
 msgid "Replace"
 msgstr "Replace"
 
-#: src/pages/Index.tsx:1554
+#: src/pages/Index.tsx:1556
 msgid "Replace current file?"
 msgstr "Replace current file?"
 
@@ -1620,7 +1620,7 @@ msgstr "Request timed out. Try downloading the file and uploading it directly."
 msgid "Resize inspector"
 msgstr "Resize inspector"
 
-#: src/pages/Index.tsx:1665
+#: src/pages/Index.tsx:1667
 msgid "Restore draft"
 msgstr "Restore draft"
 
@@ -1893,7 +1893,7 @@ msgid "Sort entries"
 msgstr "Sort entries"
 
 #: src/components/editor/EditorTable.tsx:1608
-#: src/pages/Index.tsx:1498
+#: src/pages/Index.tsx:1500
 msgid "Source"
 msgstr "Source"
 
@@ -2091,7 +2091,7 @@ msgstr ""
 "This will overwrite {{count}} existing translations with new machine transla"
 "tions."
 
-#: src/pages/Index.tsx:1541
+#: src/pages/Index.tsx:1543
 msgid "This will remove all your work on the current file."
 msgstr "This will remove all your work on the current file."
 
@@ -2108,7 +2108,7 @@ msgstr "Title"
 msgid "To"
 msgstr "To"
 
-#: src/pages/Index.tsx:1516
+#: src/pages/Index.tsx:1518
 msgid "Translate"
 msgstr "Translate"
 
@@ -2261,7 +2261,7 @@ msgstr "Unknown error"
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
 
-#: src/pages/Index.tsx:1639
+#: src/pages/Index.tsx:1641
 msgid "Unsaved draft found"
 msgstr "Unsaved draft found"
 
@@ -2308,11 +2308,11 @@ msgstr "Upload CSV"
 msgid "Upload a WordPress glossary CSV for the selected language"
 msgstr "Upload a WordPress glossary CSV for the selected language"
 
-#: src/pages/Index.tsx:1780
+#: src/pages/Index.tsx:1782
 msgid "Upload a translation file to start"
 msgstr "Upload a translation file to start"
 
-#: src/pages/Index.tsx:1568
+#: src/pages/Index.tsx:1570
 msgid "Upload failed"
 msgstr "Upload failed"
 
@@ -2451,7 +2451,7 @@ msgstr "WordPress.org plugin slug for source code links"
 msgid "You have unsaved changes"
 msgstr "You have unsaved changes"
 
-#: src/pages/Index.tsx:1647
+#: src/pages/Index.tsx:1649
 msgid ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
@@ -2459,7 +2459,7 @@ msgstr ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
 
-#: src/pages/Index.tsx:1540
+#: src/pages/Index.tsx:1542
 msgid "You have unsaved changes. Are you sure you want to clear the editor?"
 msgstr "You have unsaved changes. Are you sure you want to clear the editor?"
 
@@ -2498,7 +2498,7 @@ msgstr "just now"
 msgid "name@example.com"
 msgstr "name@example.com"
 
-#: src/pages/Index.tsx:1828
+#: src/pages/Index.tsx:1830
 msgid "or"
 msgstr "or"
 
@@ -2526,7 +2526,7 @@ msgstr "skipped"
 msgid "terms"
 msgstr "terms"
 
-#: src/pages/Index.tsx:1655
+#: src/pages/Index.tsx:1657
 msgid "{count} modified entries will be restored."
 msgstr "{count} modified entries will be restored."
 
@@ -2609,7 +2609,7 @@ msgstr "{{count}} translations failed"
 msgid "{{count}} untranslated"
 msgstr "{{count}} untranslated"
 
-#: src/pages/Index.tsx:1605
+#: src/pages/Index.tsx:1607
 msgid "{{count}} warning(s) during parsing"
 msgstr "{{count}} warning(s) during parsing"
 

--- a/src/lib/app-language/locales/app.nl.po
+++ b/src/lib/app-language/locales/app.nl.po
@@ -10,7 +10,7 @@ msgstr ""
 msgid "+{{count}} more"
 msgstr "+{{count}} meer"
 
-#: src/pages/Index.tsx:1624
+#: src/pages/Index.tsx:1626
 msgid "...and {{count}} more warnings"
 msgstr "...en nog {{count}} waarschuwingen"
 
@@ -62,7 +62,9 @@ msgstr "Voeg je DeepL API-sleutel toe in Instellingen om vertaling in te schakel
 
 #: src/components/editor/TranslateToolbar.tsx:628
 msgid "Add your DeepL API key in Settings to enable translations."
-msgstr "Voeg je DeepL API-sleutel toe in Instellingen om vertalingen in te schakelen."
+msgstr ""
+"Voeg je DeepL API-sleutel toe in Instellingen om vertalingen in te schakelen"
+"."
 
 #: src/components/SettingsModal.tsx:1603
 msgid "Adjust the appearance of the editor to suit your screen and preferences."
@@ -151,7 +153,7 @@ msgstr "Automatisch detecteren"
 msgid "Auto-detected: {{slug}}"
 msgstr "Automatisch gedetecteerd: {{slug}}"
 
-#: src/pages/Index.tsx:1691
+#: src/pages/Index.tsx:1693
 msgid "Auto-saved {age}"
 msgstr "Automatisch opgeslagen {age}"
 
@@ -280,7 +282,7 @@ msgstr "Wissen"
 msgid "Clear active source reference"
 msgstr "Actieve bronverwijzing wissen"
 
-#: src/pages/Index.tsx:1542
+#: src/pages/Index.tsx:1544
 msgid "Clear anyway"
 msgstr "Toch wissen"
 
@@ -288,7 +290,7 @@ msgstr "Toch wissen"
 msgid "Clear editor"
 msgstr "Editor wissen"
 
-#: src/pages/Index.tsx:1539
+#: src/pages/Index.tsx:1541
 msgid "Clear editor?"
 msgstr "Editor wissen?"
 
@@ -375,7 +377,9 @@ msgstr "Kroatisch"
 
 #: src/components/editor/HeaderEditor.tsx:436
 msgid "Custom expression (select a preset above to replace)"
-msgstr "Aangepaste expressie (selecteer hierboven een voorinstelling om te vervangen)"
+msgstr ""
+"Aangepaste expressie (selecteer hierboven een voorinstelling om te vervangen"
+")"
 
 #: src/components/editor/HeaderEditor.tsx:405
 msgid "Custom value set — select to change"
@@ -425,7 +429,7 @@ msgstr "DeepL gereed ({count} termen)"
 msgid "DeepL ready ({{count}} terms)"
 msgstr "DeepL gereed ({{count}} termen)"
 
-#: src/pages/Index.tsx:1726
+#: src/pages/Index.tsx:1728
 msgid "DeepL synced"
 msgstr "DeepL gesynchroniseerd"
 
@@ -473,7 +477,7 @@ msgstr "Alleen ontwikkelingsmodus"
 msgid "Directory listing is unavailable."
 msgstr "Mappenlijst is niet beschikbaar."
 
-#: src/pages/Index.tsx:1674
+#: src/pages/Index.tsx:1676
 msgid "Discard and use new file"
 msgstr "Verwijderen en nieuw bestand gebruiken"
 
@@ -505,7 +509,7 @@ msgstr "Downloaden als {format}"
 msgid "Download format options"
 msgstr "Downloadformaatopties"
 
-#: src/pages/Index.tsx:1782
+#: src/pages/Index.tsx:1784
 msgid ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
@@ -543,7 +547,7 @@ msgstr "Header bewerken"
 msgid "Edit gettext translation files with DeepL integration"
 msgstr "Bewerk gettext-vertaalbestanden met DeepL-integratie"
 
-#: src/pages/Index.tsx:1686
+#: src/pages/Index.tsx:1688
 msgid "Editing draft"
 msgstr "Concept bewerken"
 
@@ -706,7 +710,7 @@ msgid "Failed to parse POT file"
 msgstr "POT-bestand verwerken mislukt"
 
 #: src/pages/Index.tsx:664
-#: src/pages/Index.tsx:1582
+#: src/pages/Index.tsx:1584
 msgid "Failed to parse file"
 msgstr "Kan het bestand niet verwerken"
 
@@ -853,7 +857,7 @@ msgstr "Duits (Duitsland)"
 msgid "German (Switzerland)"
 msgstr "Duits (Zwitserland)"
 
-#: src/pages/Index.tsx:1490
+#: src/pages/Index.tsx:1491
 msgid "GlossBoss v{version}"
 msgstr "GlossBoss v{version}"
 
@@ -909,7 +913,7 @@ msgstr ""
 "Glossary niet gevonden in DeepL. Deze vertaling is gedaan zonder glossary. O"
 "pnieuw synchroniseren in Instellingen wordt aanbevolen."
 
-#: src/pages/Index.tsx:1719
+#: src/pages/Index.tsx:1721
 msgid "Glossary: {count} terms ({locale})"
 msgstr "Glossary: {count} termen ({locale})"
 
@@ -1104,7 +1108,7 @@ msgstr "Laatst bijgewerkt"
 msgid "Latvian"
 msgstr "Lets"
 
-#: src/pages/Index.tsx:1507
+#: src/pages/Index.tsx:1509
 msgid "License"
 msgstr "Licentie"
 
@@ -1112,7 +1116,7 @@ msgstr "Licentie"
 msgid "Light mode"
 msgstr "Lichte modus"
 
-#: src/pages/Index.tsx:1589
+#: src/pages/Index.tsx:1591
 msgid "Line {line}"
 msgstr "Regel {line}"
 
@@ -1121,7 +1125,7 @@ msgstr "Regel {line}"
 msgid "Line {{lineNumber}}"
 msgstr "Regel {{lineNumber}}"
 
-#: src/pages/Index.tsx:1616
+#: src/pages/Index.tsx:1618
 msgid "Line {{line}}"
 msgstr "Regel {{line}}"
 
@@ -1136,7 +1140,7 @@ msgid "Lithuanian"
 msgstr "Litouws"
 
 #: src/components/editor/GlossaryPanel.tsx:355
-#: src/pages/Index.tsx:1823
+#: src/pages/Index.tsx:1825
 msgid "Load"
 msgstr "Laden"
 
@@ -1144,11 +1148,11 @@ msgstr "Laden"
 msgid "Load Glossary"
 msgstr "Glossary laden"
 
-#: src/pages/Index.tsx:1831
+#: src/pages/Index.tsx:1833
 msgid "Load a small example WordPress plugin PO file (Hello Dolly)"
 msgstr "Laad een klein voorbeeld WordPress-plug-in PO-bestand (Hello Dolly)"
 
-#: src/pages/Index.tsx:1842
+#: src/pages/Index.tsx:1844
 msgid "Load example PO"
 msgstr "Voorbeeld-PO laden"
 
@@ -1165,7 +1169,7 @@ msgstr ""
 msgid "Load voices by testing your key"
 msgstr "Laad stemmen door je sleutel te testen"
 
-#: src/pages/Index.tsx:1555
+#: src/pages/Index.tsx:1557
 msgid ""
 "Loading a new file from URL will replace the currently loaded file. Any unsa"
 "ved changes will be lost."
@@ -1416,7 +1420,7 @@ msgstr "Instellingen openen"
 msgid "PO file (.po)"
 msgstr "PO-bestand (.po)"
 
-#: src/pages/Index.tsx:1806
+#: src/pages/Index.tsx:1808
 msgid "PO file URL"
 msgstr "URL van PO-bestand"
 
@@ -1424,7 +1428,7 @@ msgstr "URL van PO-bestand"
 msgid "POT Created"
 msgstr "POT aangemaakt"
 
-#: src/pages/Index.tsx:1805
+#: src/pages/Index.tsx:1807
 msgid "Paste a .po file URL"
 msgstr "Plak de URL van een .po-bestand"
 
@@ -1539,7 +1543,7 @@ msgid "Previous field"
 msgstr "Vorig veld"
 
 #: src/components/feedback/FeedbackModal.tsx:416
-#: src/pages/Index.tsx:1525
+#: src/pages/Index.tsx:1527
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -1608,11 +1612,11 @@ msgid "Remove saved key"
 msgstr "Opgeslagen sleutel verwijderen"
 
 #: src/components/editor/TranslateButton.tsx:260
-#: src/pages/Index.tsx:1558
+#: src/pages/Index.tsx:1560
 msgid "Replace"
 msgstr "Vervangen"
 
-#: src/pages/Index.tsx:1554
+#: src/pages/Index.tsx:1556
 msgid "Replace current file?"
 msgstr "Huidig bestand vervangen?"
 
@@ -1634,7 +1638,7 @@ msgstr ""
 msgid "Resize inspector"
 msgstr "Inspecteur formaat wijzigen"
 
-#: src/pages/Index.tsx:1665
+#: src/pages/Index.tsx:1667
 msgid "Restore draft"
 msgstr "Concept herstellen"
 
@@ -1909,7 +1913,7 @@ msgid "Sort entries"
 msgstr "Items sorteren"
 
 #: src/components/editor/EditorTable.tsx:1608
-#: src/pages/Index.tsx:1498
+#: src/pages/Index.tsx:1500
 msgid "Source"
 msgstr "Bron"
 
@@ -2107,7 +2111,7 @@ msgstr ""
 "Dit overschrijft {{count}} bestaande vertalingen met nieuwe automatische ver"
 "talingen."
 
-#: src/pages/Index.tsx:1541
+#: src/pages/Index.tsx:1543
 msgid "This will remove all your work on the current file."
 msgstr "Hierdoor gaat al je werk aan het huidige bestand verloren."
 
@@ -2124,7 +2128,7 @@ msgstr "Titel"
 msgid "To"
 msgstr "Naar"
 
-#: src/pages/Index.tsx:1516
+#: src/pages/Index.tsx:1518
 msgid "Translate"
 msgstr "Vertalen"
 
@@ -2279,7 +2283,7 @@ msgstr "Onbekende fout"
 msgid "Unsaved changes"
 msgstr "Onopgeslagen wijzigingen"
 
-#: src/pages/Index.tsx:1639
+#: src/pages/Index.tsx:1641
 msgid "Unsaved draft found"
 msgstr "Onopgeslagen concept gevonden"
 
@@ -2326,11 +2330,11 @@ msgstr "CSV uploaden"
 msgid "Upload a WordPress glossary CSV for the selected language"
 msgstr "Upload een WordPress-glossary CSV voor de geselecteerde taal"
 
-#: src/pages/Index.tsx:1780
+#: src/pages/Index.tsx:1782
 msgid "Upload a translation file to start"
 msgstr "Upload een vertaalbestand om te beginnen"
 
-#: src/pages/Index.tsx:1568
+#: src/pages/Index.tsx:1570
 msgid "Upload failed"
 msgstr "Uploaden mislukt"
 
@@ -2470,7 +2474,7 @@ msgstr "WordPress.org plugin-slug voor broncodekoppelingen"
 msgid "You have unsaved changes"
 msgstr "Je hebt onopgeslagen wijzigingen"
 
-#: src/pages/Index.tsx:1647
+#: src/pages/Index.tsx:1649
 msgid ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
@@ -2478,7 +2482,7 @@ msgstr ""
 "Je hebt onopgeslagen wijzigingen van {age}. Wil je je vorige werk herstellen"
 "?"
 
-#: src/pages/Index.tsx:1540
+#: src/pages/Index.tsx:1542
 msgid "You have unsaved changes. Are you sure you want to clear the editor?"
 msgstr ""
 "Je hebt onopgeslagen wijzigingen. Weet je zeker dat je de editor wilt wissen"
@@ -2519,7 +2523,7 @@ msgstr "zojuist"
 msgid "name@example.com"
 msgstr "naam@voorbeeld.nl"
 
-#: src/pages/Index.tsx:1828
+#: src/pages/Index.tsx:1830
 msgid "or"
 msgstr "of"
 
@@ -2547,7 +2551,7 @@ msgstr "overgeslagen"
 msgid "terms"
 msgstr "termen"
 
-#: src/pages/Index.tsx:1655
+#: src/pages/Index.tsx:1657
 msgid "{count} modified entries will be restored."
 msgstr "{count} gewijzigde items worden hersteld."
 
@@ -2630,7 +2634,7 @@ msgstr "{{count}} vertalingen mislukt"
 msgid "{{count}} untranslated"
 msgstr "{{count}} onvertaald"
 
-#: src/pages/Index.tsx:1605
+#: src/pages/Index.tsx:1607
 msgid "{{count}} warning(s) during parsing"
 msgstr "{{count}} waarschuwing(en) tijdens verwerking"
 

--- a/src/lib/app-language/locales/app.pot
+++ b/src/lib/app-language/locales/app.pot
@@ -9,7 +9,7 @@ msgstr ""
 msgid "+{{count}} more"
 msgstr ""
 
-#: src/pages/Index.tsx:1624
+#: src/pages/Index.tsx:1626
 msgid "...and {{count}} more warnings"
 msgstr ""
 
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Auto-detected: {{slug}}"
 msgstr ""
 
-#: src/pages/Index.tsx:1691
+#: src/pages/Index.tsx:1693
 msgid "Auto-saved {age}"
 msgstr ""
 
@@ -275,7 +275,7 @@ msgstr ""
 msgid "Clear active source reference"
 msgstr ""
 
-#: src/pages/Index.tsx:1542
+#: src/pages/Index.tsx:1544
 msgid "Clear anyway"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Clear editor"
 msgstr ""
 
-#: src/pages/Index.tsx:1539
+#: src/pages/Index.tsx:1541
 msgid "Clear editor?"
 msgstr ""
 
@@ -410,7 +410,7 @@ msgstr ""
 msgid "DeepL ready ({{count}} terms)"
 msgstr ""
 
-#: src/pages/Index.tsx:1726
+#: src/pages/Index.tsx:1728
 msgid "DeepL synced"
 msgstr ""
 
@@ -458,7 +458,7 @@ msgstr ""
 msgid "Directory listing is unavailable."
 msgstr ""
 
-#: src/pages/Index.tsx:1674
+#: src/pages/Index.tsx:1676
 msgid "Discard and use new file"
 msgstr ""
 
@@ -490,7 +490,7 @@ msgstr ""
 msgid "Download format options"
 msgstr ""
 
-#: src/pages/Index.tsx:1782
+#: src/pages/Index.tsx:1784
 msgid ""
 "Drag and drop your translation file here, or click to browse. Your translati"
 "ons will be saved locally in your browser."
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Edit gettext translation files with DeepL integration"
 msgstr ""
 
-#: src/pages/Index.tsx:1686
+#: src/pages/Index.tsx:1688
 msgid "Editing draft"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgid "Failed to parse POT file"
 msgstr ""
 
 #: src/pages/Index.tsx:664
-#: src/pages/Index.tsx:1582
+#: src/pages/Index.tsx:1584
 msgid "Failed to parse file"
 msgstr ""
 
@@ -823,7 +823,7 @@ msgstr ""
 msgid "German (Switzerland)"
 msgstr ""
 
-#: src/pages/Index.tsx:1490
+#: src/pages/Index.tsx:1491
 msgid "GlossBoss v{version}"
 msgstr ""
 
@@ -869,7 +869,7 @@ msgid ""
 "sync in Settings is recommended."
 msgstr ""
 
-#: src/pages/Index.tsx:1719
+#: src/pages/Index.tsx:1721
 msgid "Glossary: {count} terms ({locale})"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Latvian"
 msgstr ""
 
-#: src/pages/Index.tsx:1507
+#: src/pages/Index.tsx:1509
 msgid "License"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Light mode"
 msgstr ""
 
-#: src/pages/Index.tsx:1589
+#: src/pages/Index.tsx:1591
 msgid "Line {line}"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Line {{lineNumber}}"
 msgstr ""
 
-#: src/pages/Index.tsx:1616
+#: src/pages/Index.tsx:1618
 msgid "Line {{line}}"
 msgstr ""
 
@@ -1094,7 +1094,7 @@ msgid "Lithuanian"
 msgstr ""
 
 #: src/components/editor/GlossaryPanel.tsx:355
-#: src/pages/Index.tsx:1823
+#: src/pages/Index.tsx:1825
 msgid "Load"
 msgstr ""
 
@@ -1102,11 +1102,11 @@ msgstr ""
 msgid "Load Glossary"
 msgstr ""
 
-#: src/pages/Index.tsx:1831
+#: src/pages/Index.tsx:1833
 msgid "Load a small example WordPress plugin PO file (Hello Dolly)"
 msgstr ""
 
-#: src/pages/Index.tsx:1842
+#: src/pages/Index.tsx:1844
 msgid "Load example PO"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Load voices by testing your key"
 msgstr ""
 
-#: src/pages/Index.tsx:1555
+#: src/pages/Index.tsx:1557
 msgid ""
 "Loading a new file from URL will replace the currently loaded file. Any unsa"
 "ved changes will be lost."
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "PO file (.po)"
 msgstr ""
 
-#: src/pages/Index.tsx:1806
+#: src/pages/Index.tsx:1808
 msgid "PO file URL"
 msgstr ""
 
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "POT Created"
 msgstr ""
 
-#: src/pages/Index.tsx:1805
+#: src/pages/Index.tsx:1807
 msgid "Paste a .po file URL"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgid "Previous field"
 msgstr ""
 
 #: src/components/feedback/FeedbackModal.tsx:416
-#: src/pages/Index.tsx:1525
+#: src/pages/Index.tsx:1527
 msgid "Privacy"
 msgstr ""
 
@@ -1559,11 +1559,11 @@ msgid "Remove saved key"
 msgstr ""
 
 #: src/components/editor/TranslateButton.tsx:260
-#: src/pages/Index.tsx:1558
+#: src/pages/Index.tsx:1560
 msgid "Replace"
 msgstr ""
 
-#: src/pages/Index.tsx:1554
+#: src/pages/Index.tsx:1556
 msgid "Replace current file?"
 msgstr ""
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "Resize inspector"
 msgstr ""
 
-#: src/pages/Index.tsx:1665
+#: src/pages/Index.tsx:1667
 msgid "Restore draft"
 msgstr ""
 
@@ -1854,7 +1854,7 @@ msgid "Sort entries"
 msgstr ""
 
 #: src/components/editor/EditorTable.tsx:1608
-#: src/pages/Index.tsx:1498
+#: src/pages/Index.tsx:1500
 msgid "Source"
 msgstr ""
 
@@ -2046,7 +2046,7 @@ msgid ""
 "tions."
 msgstr ""
 
-#: src/pages/Index.tsx:1541
+#: src/pages/Index.tsx:1543
 msgid "This will remove all your work on the current file."
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: src/pages/Index.tsx:1516
+#: src/pages/Index.tsx:1518
 msgid "Translate"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Unsaved changes"
 msgstr ""
 
-#: src/pages/Index.tsx:1639
+#: src/pages/Index.tsx:1641
 msgid "Unsaved draft found"
 msgstr ""
 
@@ -2258,11 +2258,11 @@ msgstr ""
 msgid "Upload a WordPress glossary CSV for the selected language"
 msgstr ""
 
-#: src/pages/Index.tsx:1780
+#: src/pages/Index.tsx:1782
 msgid "Upload a translation file to start"
 msgstr ""
 
-#: src/pages/Index.tsx:1568
+#: src/pages/Index.tsx:1570
 msgid "Upload failed"
 msgstr ""
 
@@ -2393,13 +2393,13 @@ msgstr ""
 msgid "You have unsaved changes"
 msgstr ""
 
-#: src/pages/Index.tsx:1647
+#: src/pages/Index.tsx:1649
 msgid ""
 "You have unsaved changes from {age}. Would you like to restore your previous"
 " work?"
 msgstr ""
 
-#: src/pages/Index.tsx:1540
+#: src/pages/Index.tsx:1542
 msgid "You have unsaved changes. Are you sure you want to clear the editor?"
 msgstr ""
 
@@ -2435,7 +2435,7 @@ msgstr ""
 msgid "name@example.com"
 msgstr ""
 
-#: src/pages/Index.tsx:1828
+#: src/pages/Index.tsx:1830
 msgid "or"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "terms"
 msgstr ""
 
-#: src/pages/Index.tsx:1655
+#: src/pages/Index.tsx:1657
 msgid "{count} modified entries will be restored."
 msgstr ""
 
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "{{count}} untranslated"
 msgstr ""
 
-#: src/pages/Index.tsx:1605
+#: src/pages/Index.tsx:1607
 msgid "{{count}} warning(s) during parsing"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- Regenerates PO/POT files to update stale line-number references in `src/pages/Index.tsx` after the UI redesign PR (#60)
- Fixes the failing **i18n Sync Check** CI job

## Test plan
- [x] `bun run i18n:sync-en --check` passes
- [x] `bun run i18n:extract` + `git diff --exit-code` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation file metadata and source location references to maintain consistency with the codebase structure. No changes to translation content or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->